### PR TITLE
Fix a bug when converting the YAML quoted implicit numerical string values into JSON.

### DIFF
--- a/MSBuild.Yaml.Tests/YamlToJsonTest.cs
+++ b/MSBuild.Yaml.Tests/YamlToJsonTest.cs
@@ -53,6 +53,8 @@ object:
 - decimalValue: 11.22
 - stringValue: ""Blabla""
 - stringValue2: 'Blabla'
+- stringValueWithInteger: '12345'
+- stringValueWithDecimal: '12.34'
 - nullValue: 
 - innerObject:
     innerIntValue: 1234
@@ -101,6 +103,12 @@ object:
       ""stringValue2"": ""Blabla""
     },
     {
+      ""stringValueWithInteger"": ""12345""
+    },
+    {
+      ""stringValueWithDecimal"": ""12.34""
+    },
+    {
       ""nullValue"": null
     },
     {
@@ -131,6 +139,8 @@ object:
 - decimalValue: 11.22
 - stringValue: ""Blabla""
 - stringValue2: 'Blabla'
+- stringValueWithInteger: '12345'
+- stringValueWithDecimal: '12.34'
 - nullValue: 
 - innerObject:
     innerIntValue: 1234
@@ -161,7 +171,7 @@ object:
 
             var json = File.ReadAllText(@"sub\folder\json.json");
 
-            json.Should().Be(@"{""object"":[{""value"":""v1""},{""booleanValue"":false},{""decimalValue"":11.22},{""stringValue"":""Blabla""},{""stringValue2"":""Blabla""},{""nullValue"":null},{""innerObject"":{""innerIntValue"":1234}}]}");
+            json.Should().Be(@"{""object"":[{""value"":""v1""},{""booleanValue"":false},{""decimalValue"":11.22},{""stringValue"":""Blabla""},{""stringValue2"":""Blabla""},{""stringValueWithInteger"":""12345""},{""stringValueWithDecimal"":""12.34""},{""nullValue"":null},{""innerObject"":{""innerIntValue"":1234}}]}");
            
             buildEngine.Verify(b => b.LogMessageEvent(It.IsAny<BuildMessageEventArgs>()));
         }

--- a/MSBuild.Yaml/YamlToJson.cs
+++ b/MSBuild.Yaml/YamlToJson.cs
@@ -130,6 +130,13 @@ namespace PosInformatique.MSBuild.Yaml
 
                         return true;
                     }
+                    else if (scalar.IsQuotedImplicit)
+                    {
+                        value = scalar.Value;
+                        reader.MoveNext();
+
+                        return true;
+                    }
                     else if (bool.TryParse(scalar.Value, out bool booleanValue))
                     {
                         value = booleanValue;


### PR DESCRIPTION
Fix the bug #9 to not convert the string values that contains numerical values into a JSON numerical raw value.